### PR TITLE
Minor comments

### DIFF
--- a/draft-thomson-httpapi-date-requests.md
+++ b/draft-thomson-httpapi-date-requests.md
@@ -98,8 +98,7 @@ time over which delay or replay is possible.
 
 Signed HTTP requests {{SIGN}} and JSON Web Tokens {{?JWT=RFC7519}} are other
 examples of where requests - or parts of requests - might be protected to
-mitigate certain attacks by intermediaries.
-Adding timestamps using a `Date`
+mitigate certain attacks by intermediaries.  Adding timestamps using a `Date`
 header field or some other mechanism (`created` for {{?SIGN}} or `iat` for {{?JWT}})
 and signing that information can ensure that the request cannot be captured and
 used at a very different time to what was intended.

--- a/draft-thomson-httpapi-date-requests.md
+++ b/draft-thomson-httpapi-date-requests.md
@@ -98,9 +98,9 @@ time over which delay or replay is possible.
 
 Signed HTTP requests {{SIGN}} and JSON Web Tokens {{?JWT=RFC7519}} are other
 examples of where requests - or parts of requests - might be protected to
-prevent certain attacks by intermediaries.  Signatures are often used to enhance
-protections for requests for privileged action on resources.  Adding a `Date`
-header field or some other field (`created` for {{?SIGN}} or `iat` for {{?JWT}})
+mitigate certain attacks by intermediaries.
+Adding timestamps using a `Date`
+header field or some other mechanism (`created` for {{?SIGN}} or `iat` for {{?JWT}})
 and signing that information can ensure that the request cannot be captured and
 used at a very different time to what was intended.
 


### PR DESCRIPTION
## Preliminary feedback

- do we need to tie it to privileged actions?

- to be expanded: use cases like signatures specify a time interval, not just a timestamp... in this perspective, line 103  can be misleading.

Question:  shouldn't replay attacks to be addressed with a unique identifier ?
Probably timestamps only address the intercept and reuse (without replay) kind of attack, but this is your field :P

